### PR TITLE
Add UNIQUE_TYPE_KEY to make classes unique

### DIFF
--- a/java/yass/main/ch/softappeal/yass/generate/TypeScriptGenerator.java
+++ b/java/yass/main/ch/softappeal/yass/generate/TypeScriptGenerator.java
@@ -71,7 +71,9 @@ public final class TypeScriptGenerator extends Generator {
     }
 
     private final class TypeScriptOut extends Out {
-
+        
+        private static final String UNIQUE_TYPE_KEY = "protected readonly __TYPE_KEY__: never;";
+        
         private final LinkedHashMap<Class<?>, Integer> type2id = new LinkedHashMap<>();
         private final Set<Class<?>> visitedClasses = new HashSet<>();
         private final Map<Class<?>, ExternalDesc> externalTypes = new HashMap<>();
@@ -109,6 +111,7 @@ public final class TypeScriptGenerator extends Generator {
             generateType(type, name -> {
                 tabsln("export class %s extends yass.Enum {", name);
                 inc();
+                tabsln(UNIQUE_TYPE_KEY);
                 for (final Enum<?> e : type.getEnumConstants()) {
                     tabsln("static readonly %s = new %s(%s, '%s');", e.name(), name, e.ordinal(), e.name());
                 }
@@ -199,6 +202,7 @@ public final class TypeScriptGenerator extends Generator {
                 }
                 println(" {");
                 inc();
+                tabsln(UNIQUE_TYPE_KEY);
                 for (final var field : Reflect.ownFields(type)) {
                     tabsln("%s: %s;", field.getName(), nullable(type(field.getGenericType())));
                 }


### PR DESCRIPTION
Add __TYPE_KEY__ prop to generated TypeScript classes & enums to ensure their uniqueness.

Before this change, the following example output would compile just fine (which might be the expected behavior for JavaScript)

```
class Currency {}
class Side {
    static readonly Buy = 'Buy'
    static readonly Sell = 'Sell'
}

const s: Side = new Currency();
```

With the introduction of this change, the generated output will look as follows and will no longer compile

```
class Currency {
    protected readonly __TYPE_KEY__: never;
}
class Side {
    protected readonly __TYPE_KEY__: never;
    static readonly Buy = 'Buy'
    static readonly Sell = 'Sell'
}

const s: Side = new Currency(); // <-- tsc will fail here
```

What is missing in this pull request is the ability to enable or disable this behavior. I think it should be disabled by default.